### PR TITLE
Added webpack compilation stats to files object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,10 @@ function plugin(config) {
                     contents: fs.readFileSync(filePath)
                 }
             })
+
+            for (var file in files) {
+                files[file].webpackStats = stats
+            }
             return done()
         })
     }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "devDependencies": {
     "assert-dir-equal": "^1.0.1",
     "crispy": "^2.0.0",
+    "jscs": "^2.9.0",
+    "jshint": "^2.9.1",
     "metalsmith": "^1.0.1",
     "mocha": "^2.0.1",
     "should": "^4.3.0"

--- a/test/index.js
+++ b/test/index.js
@@ -43,4 +43,27 @@ describe('metalsmith-webpack', function () {
             })
     })
 
+    it('should add webpack stats', function (done) {
+        (new Metalsmith('test/fixtures/complex'))
+            .use(webpack({
+                context: path.resolve(__dirname, './fixtures/complex/src/js'),
+                entry: {
+                    a: './index-a.js',
+                    b: './index-b.js'
+                },
+                output: {
+                    path: path.resolve(__dirname, './fixtures/complex/build/js'),
+                    filename: '[name]-bundle.js'
+                }
+            }))
+            .build(function (err, files) {
+                if (err) return done(err)
+                Object.keys(files).forEach(function (file) {
+                    files[file].should.be.an.instanceOf(Object).and.have.property('webpackStats')
+                    files[file].webpackStats.should.be.an.instanceOf(Object).and.have.property('hash')
+                })
+                return done(null)
+            })
+    })
+
 })


### PR DESCRIPTION
This allows using webpack compilation stats in other plugins.

For instance, to enable caching, you might want to use webpack compilation hash when requiring your assets in production. Now you can do this like

``` handlebars
{{#if config.production }}
<script src="/bundle.{{ webpackStats.hash }}.js"></script>
{{else}}
<script src="/bundle.js"></script>
{{/if}}
```
