### PR TITLE
Allow config to be an array of config objects.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ module.exports = plugin
 function plugin(config) {
 
     if (!Array.isArray(config)) {
-        config = [config];
+        config = [config]
     }
 
     var compiler = webpack(config)

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,11 @@ var webpack = require('webpack')
 module.exports = plugin
 
 function plugin(config) {
+
+    if (!Array.isArray(config)) {
+        config = [config];
+    }
+
     var compiler = webpack(config)
     var files = {}
     var fs = new MemoryInputFileSystem(files)
@@ -23,12 +28,16 @@ function plugin(config) {
                 return
             }
             console.log(info)
-            fs.readdirSync(config.output.path).forEach(function (file) {
-                var filePath = path.join(config.output.path, file)
-                var key = getMetalsmithKey(files, filePath) || filePath
-                files[key] = {
-                    contents: fs.readFileSync(filePath)
-                }
+
+            config.forEach(function (conf) {
+                fs.readdirSync(conf.output.path).forEach(function (file) {
+                    var filePath = path.join(conf.output.path, file)
+                    var key = getMetalsmithKey(files, filePath) || filePath
+                    files[key] = {
+                        filePath: filePath,
+                        contents: fs.readFileSync(filePath)
+                    }
+                })
             })
             return done()
         })


### PR DESCRIPTION
This PR allows the webpack config argument to be an array to support [multiple configurations](http://webpack.github.io/docs/configuration.html#multiple-configurations). It also adds a `filePath` key to the file objects for convenience.
