### PR TITLE
Correctly update the metalsmith file index

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,10 @@ function plugin(config) {
             console.log(info)
             fs.readdirSync(config.output.path).forEach(function (file) {
                 var filePath = path.join(config.output.path, file)
-                var key = getMetalsmithKey(files, filePath) || filePath
+                // the internal map handles relative paths, if you give it
+                // absolute paths it will not write these files to the disk
+                var relFilePath = path.relative(metalsmith.source(), filePath)
+                var key = getMetalsmithKey(files, relFilePath) || relFilePath
                 files[key] = {
                     contents: fs.readFileSync(filePath)
                 }


### PR DESCRIPTION
Currently we add an absolute path, while the index holds paths relative to the source directory. This means the webpack generated files will not automatically show up in the build, if your webpack output directory is within the source directory it will however show up after the second run, when metalsmith picks the changed files up on his own, but even then the modified key above does not have any effect.
